### PR TITLE
Update generateToken in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const {
 
 ```js
 const myRoute = (request, response) => {
-  const csrfToken = generateToken(response);
+  const csrfToken = generateToken(response, request);
   // You could also pass the token into the context of a HTML response.
   res.json({ csrfToken });
 };


### PR DESCRIPTION
If `request` is not passed to `generateToken`, then `getSecret` can't get request like `(request) => ...`