### PR TITLE
docs: add async example

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,27 @@ However it is highly recommend you implement some rotating secret key so that to
 // or some other externally rotated secret key
 ```
 
+<h2>Using asynchronously</h2>
+
+<p>csrf-csrf itself will not support promises or async, <b>however</b> there is a way around this. If your csrf token is stored externally and needs to be retrieved asynchronously, you can register an asynchronous middleware first, which exposes the token.</p>
+
+```js
+(req, res, next) => {
+  getCsrfTokenAsync(req)
+    .then((token) => {
+      req.asyncCsrfToken = token;
+      next();
+    })
+    .catch((error) => next(error));
+};
+```
+
+<p>And in this example, your <code>getTokenFromRequest</code> would look like this:</p>
+
+```js
+(req) => req.asyncCsrfToken;
+```
+
 <h2 id="support"> Support</h2>
 
 <ul>


### PR DESCRIPTION
Adds the async example to the doc, this will fix issue #5 