### PR TITLE
chore: bump security supported version

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| >= 2.2.1 | :white_check_mark: |
-| <= 2.2.0 | :x:                |
+| >= 2.3.0 | :white_check_mark: |
+| < 2.3.0  | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Bumping supported version to >= v2.3.0 due to the dev audit fixes and the enforce http only change.