### PR TITLE
refactor/reverse generate token parameter order

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ const {
 
 ```js
 const myRoute = (request, response) => {
-  const csrfToken = generateToken(response, request);
+  const csrfToken = generateToken(request, response);
   // You could also pass the token into the context of a HTML response.
   res.json({ csrfToken });
 };
@@ -125,7 +125,7 @@ const myProtectedRoute = (req, res) =>
 <p>Instead of importing and using <code>generateToken</code>, you can also use <code>req.csrfToken</code> any time after the <code>doubleCsrfProtection</code> middleware has executed on your incoming request.</p>
 
 ```js
-request.csrfToken(); // same as generateToken(res, req);
+request.csrfToken(); // same as generateToken(req, res);
 ```
 
 <p>
@@ -324,20 +324,20 @@ number;
 <h3>generateToken</h3>
 
 ```ts
-(response: Response, request: Request, overwrite?: boolean) => string;
+(request: Request, response: Response, overwrite?: boolean) => string;
 ```
 
 <p>By default if a csrf-csrf cookie already exists on an incoming request, generateToken will not overwrite it, it will simply return the existing token. If you wish to force a token generation, you can use the third parameter:</p>
 
 ```ts
-generateToken(res, req, true); // This will force a new token to be generated, and a new cookie to be set, even if one already exists
+generateToken(req, res, true); // This will force a new token to be generated, and a new cookie to be set, even if one already exists
 ```
 
 <p>Instead of importing and using generateToken, you can also use req.csrfToken any time after the doubleCsrfProtection middleware has executed on your incoming request.</p>
 
 ```ts
-req.csrfToken(); // same as generateToken(res, req) and generateToken(res, req, false);
-req.csrfToken(true); // same as generateToken(res, req, true);
+req.csrfToken(); // same as generateToken(req, res) and generateToken(req, res, false);
+req.csrfToken(true); // same as generateToken(req, res, true);
 ```
 
 <p>The <code>generateToken</code> function serves the purpose of establishing a CSRF (Cross-Site Request Forgery) protection mechanism by generating a token and an associated cookie. This function also provides the option to utilize a third parameter called <code>overwrite</code>. By default, this parameter is set to <em>false</em>.</p>

--- a/example/complete/src/index.js
+++ b/example/complete/src/index.js
@@ -47,7 +47,7 @@ app.get("/", function (req, res) {
 
 app.get("/csrf-token", (req, res) => {
   return res.json({
-    token: generateToken(res, req),
+    token: generateToken(req, res),
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,8 @@ export type CsrfCookieSetter = (
   options: DoubleCsrfCookieOptions
 ) => void;
 export type CsrfTokenCreator = (
-  res: Response,
   req: Request,
+  res: Response,
   ovewrite?: boolean
 ) => string;
 
@@ -131,8 +131,8 @@ export function doubleCsrf({
   // Do NOT send the csrfToken as a cookie, embed it in your HTML response, or as JSON.
 
   const generateToken: CsrfTokenCreator = (
-    res: Response,
     req: Request,
+    res: Response,
     overwrite?: boolean
   ) => {
     const { csrfToken, csrfTokenHash } = generateTokenAndHash(req, overwrite);
@@ -180,7 +180,7 @@ export function doubleCsrf({
   };
 
   const doubleCsrfProtection: doubleCsrfProtection = (req, res, next) => {
-    req.csrfToken = (overwrite?: boolean) => generateToken(res, req, overwrite);
+    req.csrfToken = (overwrite?: boolean) => generateToken(req, res, overwrite);
     if (ignoredMethodsSet.has(req.method as RequestMethod)) {
       next();
     } else if (validateRequest(req)) {

--- a/src/tests/testsuite.ts
+++ b/src/tests/testsuite.ts
@@ -87,7 +87,7 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
         mockResponse.setHeader("set-cookie", []);
 
         // overwrite is false by default
-        const generatedToken = generateToken(mockResponse, mockRequest);
+        const generatedToken = generateToken(mockRequest, mockResponse);
         const newCookieValue = getCookieFromResponse(mockResponse);
 
         assert.equal(generatedToken, csrfToken);
@@ -105,7 +105,7 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
         // reset the mock response to have no cookies (in reality this would just be a new instance of Response)
         mockResponse.setHeader("set-cookie", []);
 
-        const generatedToken = generateToken(mockResponse, mockRequest, true);
+        const generatedToken = generateToken(mockRequest, mockResponse, true);
         const newCookieValue = getCookieFromResponse(mockResponse);
 
         assert.notEqual(newCookieValue, oldCookieValue);
@@ -124,7 +124,7 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
           : (mockRequest.cookies[cookieName] =
               (decodedCookieValue as string).split("|")[0] + "|invalid-hash");
 
-        expect(() => generateToken(mockResponse, mockRequest)).to.throw(
+        expect(() => generateToken(mockRequest, mockResponse)).to.throw(
           invalidCsrfTokenError.message
         );
 
@@ -136,7 +136,7 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
             )}`)
           : (mockRequest.cookies[cookieName] = "invalid-value");
 
-        expect(() => generateToken(mockResponse, mockRequest)).to.throw(
+        expect(() => generateToken(mockRequest, mockResponse)).to.throw(
           invalidCsrfTokenError.message
         );
       });

--- a/src/tests/utils/mock.ts
+++ b/src/tests/utils/mock.ts
@@ -81,7 +81,7 @@ export const generateMocksWithToken = ({
 }: GenerateMocksWithTokenOptions) => {
   const { mockRequest, mockResponse, mockResponseHeaders } = generateMocks();
 
-  const csrfToken = generateToken(mockResponse, mockRequest);
+  const csrfToken = generateToken(mockRequest, mockResponse);
   const { setCookie, cookieValue } = getCookieValueFromResponse(mockResponse);
   mockRequest.headers.cookie = `${cookieName}=${cookieValue};`;
   const decodedCookieValue = signed


### PR DESCRIPTION
Expands and revamps the documentation and swaps the parameter order for `generateToken`.

