### PR TITLE
Improve CommonJS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": {
       "require": {
-        "types": "./lib/index.d.ts",
+        "types": "./lib/index.d.cts",
         "default": "./lib/cjs/index.cjs"
       },
       "import": {
@@ -20,7 +20,8 @@
   "files": [
     "lib/esm/index.js",
     "lib/cjs/index.cjs",
-    "lib/index.d.ts"
+    "lib/index.d.ts",
+    "lib/index.d.cts"
   ],
   "scripts": {
     "test": "mocha --recursive ./src/tests/*.test.ts",
@@ -28,7 +29,7 @@
     "lint": "npx eslint .",
     "prettify": "npx prettier --write .",
     "build:types": "tsc --declaration --outDir ./lib --emitDeclarationOnly",
-    "build:cjs": "tsc -p tsconfig.cjs.json && mv ./lib/cjs/index.js ./lib/cjs/index.cjs",
+    "build:cjs": "tsc -p tsconfig.cjs.json && mv ./lib/cjs/index.js ./lib/cjs/index.cjs && cp ./lib/index.d.ts ./lib/index.d.cts",
     "build:esm": "tsc -p tsconfig.json",
     "build": "npm run build:types && npm run build:esm && npm run build:cjs",
     "build:clean": "npm run clean && npm run build",


### PR DESCRIPTION
Currently importing the library in a CommonJS Typescript project with the following tsconfig settings:  
```
"compilerOptions": {
    "module": "Node16",
    "moduleResolution": "Node16",
}
```
fails with this message:

> error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("csrf-csrf")' call instead.

The solution is to have a separate CommonJS types definition file with a .cts extension.
