### PR TITLE
feat: allow customizable error

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,29 @@ number;
 
 <p>The size in bytes of the tokens that will be generated, if you plan on re-generating tokens consider dropping this to 32.</p>
 
+<h3 id="configuration-error-config">errorConfig</h3>
+
+```ts
+statusCode?: number;
+message?: string;
+code?: string | undefined;
+```
+
+<p>
+  <b>Optional<br />
+  Default:</b>
+</p>
+
+```ts
+{
+  statusCode: 403,
+  message: "invalid csrf token",
+  code: "EBADCSRFTOKEN"
+}
+```
+
+Used to customise the error response <code>statusCode</code>, the contained error <code>message</code>, and it's <code>code</code>, the error is constructed via <code>createHttpError</code>. The default values match that of <code>csurf</code> for convenience.
+
 <h2 id="utilities">Utilities</h2>
 
 <p>Below is the documentation for what doubleCsrf returns.</p>
@@ -366,7 +389,7 @@ req.csrfToken(false, false); // same as generateToken(req, res, false, false);
 
 <h3>invalidCsrfTokenError</h3>
 
-<p>This is the error instance that gets passed as an error to the <code>next</code> call, by default this will be handled by the <a target="_blank" href="https://expressjs.com/en/guide/error-handling.html">default error handler</a>.</p>
+<p>This is the error instance that gets passed as an error to the <code>next</code> call, by default this will be handled by the <a target="_blank" href="https://expressjs.com/en/guide/error-handling.html">default error handler</a>. This error is customizable via the <a href="#configuration-error-config">errorConfig</a>.</p>
 
 <h3>validateToken</h3>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,11 @@ export function doubleCsrf({
   size = 64,
   ignoredMethods = ["GET", "HEAD", "OPTIONS"],
   getTokenFromRequest = (req) => req.headers["x-csrf-token"],
+  errorConfig: {
+    statusCode = 403,
+    message = "invalid csrf token",
+    code = "EBADCSRFTOKEN",
+  } = {},
 }: DoubleCsrfConfigOptions): DoubleCsrfUtilities {
   const ignoredMethodsSet = new Set(ignoredMethods);
   const cookieOptions = {
@@ -35,8 +40,8 @@ export function doubleCsrf({
     ...remainingCookieOptions,
   };
 
-  const invalidCsrfTokenError = createHttpError(403, "invalid csrf token", {
-    code: "EBADCSRFTOKEN",
+  const invalidCsrfTokenError = createHttpError(statusCode, message, {
+    code: code,
   });
 
   const generateTokenAndHash = (

--- a/src/tests/doublecsrf.test.ts
+++ b/src/tests/doublecsrf.test.ts
@@ -17,6 +17,11 @@ createTestSuite("csrf-csrf unsigned, single secret", {
 createTestSuite("csrf-csrf signed, single secret", {
   cookieOptions: { signed: true },
   getSecret: getSingleSecret,
+  errorConfig: {
+    statusCode: 400,
+    message: "NOT GOOD",
+    code: "BADTOKEN",
+  },
 });
 createTestSuite("csrf-csrf signed with custom options, single secret", {
   getSecret: getSingleSecret,
@@ -37,6 +42,11 @@ createTestSuite("csrf-csrf signed with custom options, multiple secrets", {
   cookieOptions: { signed: true, sameSite: "strict" },
   size: 128,
   cookieName: "__Host.test-the-thing.token",
+  errorConfig: {
+    statusCode: 401,
+    message: "GO AWAY",
+    code: "FAKE",
+  },
 });
 
 describe("csrf-csrf token-rotation", () => {

--- a/src/tests/testsuite.ts
+++ b/src/tests/testsuite.ts
@@ -43,6 +43,11 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
         secure = true,
         sameSite = "lax",
       } = {},
+      errorConfig = {
+        statusCode: 403,
+        message: "invalid csrf token",
+        code: "EBADCSRFTOKEN",
+      },
     } = doubleCsrfOptions;
 
     const generateMocksWithTokenIntenral = () =>
@@ -52,6 +57,13 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
         generateToken,
         validateRequest,
       });
+
+    it("should initialize error via config options", () => {
+      console.log(invalidCsrfTokenError);
+      assert.equal(errorConfig.message, invalidCsrfTokenError.message);
+      assert.equal(errorConfig.statusCode, invalidCsrfTokenError.statusCode);
+      assert.equal(errorConfig.code, invalidCsrfTokenError.code);
+    });
 
     describe("generateToken", () => {
       it("should attach both a token and its hash to the response and return a token", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,12 @@ export type CsrfTokenCreator = (
   ovewrite?: boolean,
   validateOnReuse?: boolean,
 ) => string;
+export type CsrfErrorConfig = {
+  statusCode: number;
+  message: string;
+  code: string | undefined;
+};
+export type CsrfErrorConfigOptions = Partial<CsrfErrorConfig>;
 
 export interface DoubleCsrfConfig {
   /**
@@ -114,6 +120,12 @@ export interface DoubleCsrfConfig {
    * ```
    */
   getTokenFromRequest: TokenRetriever;
+
+  /**
+   * Configuration for the error that is thrown any time XSRF token validation fails.
+   * @default { statusCode: 403, message: "invalid csrf token", code: "EBADCSRFTOKEN" }
+   */
+  errorConfig: CsrfErrorConfigOptions;
 }
 
 export interface DoubleCsrfUtilities {


### PR DESCRIPTION
Exposes the statusCode, message, and code parameters for the error initialization

This will fix issue #55 