### PR TITLE
Refactor/parameter cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,24 +360,26 @@ Used to customise the error response <code>statusCode</code>, the contained erro
 <p>By default if a csrf-csrf cookie already exists on an incoming request, generateToken will not overwrite it, it will simply return the existing token so long as the token is valid. If you wish to force a token generation, you can use the third parameter:</p>
 
 ```ts
-generateToken(req, res, true); // This will force a new token to be generated, and a new cookie to be set, even if one already exists
+generateToken(req, res, { overwrite: true }); // This will force a new token to be generated, and a new cookie to be set, even if one already exists
 ```
 
 <p>If the 'overwrite' parameter is set to false (default), the existing token will be re-used and returned. However, the cookie value will also be validated. If the validation fails an error will be thrown. If you don't want an error to be thrown, you can set the 'validateOnReuse' (by default, true) to false. In this case instead of throwing an error, a new token will be generated and returned.
 </p>
 
 ```ts
-generateToken(req, res, true); // As overwrite is true, an error will never be thrown.
-generateToken(req, res, false); // As validateOnReuse is true (default), an error will be thrown if the cookie is invalid.
-generateToken(req, res, false, false); // As validateOnReuse is false, an error will never be thrown, even if the cookie is invalid. Instead, a new cookie will be generated if it is found to be invalid.
+generateToken(req, res, { overwrite: true }); // As overwrite is true, an error will never be thrown.
+generateToken(req, res, { overwrite: false }); // As validateOnReuse is true (default), an error will be thrown if the cookie is invalid.
+generateToken(req, res, { overwrite: false, validateOnReuse: false }); // As validateOnReuse is false, if the cookie is invalid a new token will be generated without any error being thrown and despite overwrite being false
 ```
 
 <p>Instead of importing and using generateToken, you can also use req.csrfToken any time after the doubleCsrfProtection middleware has executed on your incoming request.</p>
 
 ```ts
-req.csrfToken(); // same as generateToken(req, res) and generateToken(req, res, false);
-req.csrfToken(true); // same as generateToken(req, res, true);
-req.csrfToken(false, false); // same as generateToken(req, res, false, false);
+req.csrfToken(); // same as generateToken(req, res);
+req.csrfToken({ overwrite: true }); // same as generateToken(req, res, { overwrite: true, validateOnReuse });
+req.csrfToken({ overwrite: false, validateOnReuse: false }); // same as generateToken(req, res, { overwrite: false, validateOnReuse: false });
+req.csrfToken(req, res, { overwrite: false });
+req.csrfToken(req, res, { overwrite: false, validateOnReuse: false });
 ```
 
 <p>The <code>generateToken</code> function serves the purpose of establishing a CSRF (Cross-Site Request Forgery) protection mechanism by generating a token and an associated cookie. This function also provides the option to utilize a third parameter called <code>overwrite</code>, and a fourth parameter called <code>validateOnReuse</code>. By default, <code>overwrite</code> is set to <em>false</em>, and <code>validateOnReuse</code> is set to <em>true</em>.</p>

--- a/README.md
+++ b/README.md
@@ -352,8 +352,10 @@ Used to customise the error response <code>statusCode</code>, the contained erro
 (
   request: Request,
   response: Response,
-  overwrite?: boolean, // Set to true to force a new token to be generated
-  validateOnReuse?: boolean, // Set to false to generate a new token if token re-use is invalid
+  {
+    overwrite?: boolean, // Set to true to force a new token to be generated
+    validateOnReuse?: boolean, // Set to false to generate a new token if token re-use is invalid
+  } // optional
 ) => string;
 ```
 

--- a/example/complete/package.json
+++ b/example/complete/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "cookie-parser": "^1.4.6",
-    "csrf-csrf": "latest",
-    "express": "^4.18.1"
+    "csrf-csrf": "file:../..",
+    "express": "^4.19.2"
   }
 }

--- a/example/complete/src/index.js
+++ b/example/complete/src/index.js
@@ -24,7 +24,7 @@ const { invalidCsrfTokenError, generateToken, doubleCsrfProtection } =
   doubleCsrf({
     getSecret: () => CSRF_SECRET,
     cookieName: CSRF_COOKIE_NAME,
-    cookieOptions: { sameSite: false, secure: false, signed: true }, // not ideal for production, development only
+    cookieOptions: { sameSite: false, secure: false }, // not ideal for production, development only
   });
 
 app.use(cookieParser(COOKIES_SECRET));

--- a/example/simple/package.json
+++ b/example/simple/package.json
@@ -11,8 +11,8 @@
   "author": "psibean",
   "license": "ISC",
   "dependencies": {
-    "csrf-csrf": "latest",
-    "express": "^4.18.1",
+    "csrf-csrf": "../..",
+    "express": "^4.19.2",
     "cookie-parser": "^1.4.6"
   }
 }

--- a/example/simple/src/index.js
+++ b/example/simple/src/index.js
@@ -11,7 +11,7 @@ const port = 5555;
 const { doubleCsrfProtection } = doubleCsrf({
   getSecret: () => "this is a test", // NEVER DO THIS
   cookieName: "x-csrf-test", // Prefer "__Host-" prefixed names if possible
-  cookieOptions: { sameSite: false, secure: false, signed: true }, // not ideal for production, development only
+  cookieOptions: { sameSite: false, secure: false }, // not ideal for production, development only
 });
 
 app.use(cookieParser("some super secret thing, please do not copy this"));

--- a/src/tests/doublecsrf.test.ts
+++ b/src/tests/doublecsrf.test.ts
@@ -200,11 +200,9 @@ describe("csrf-csrf token-rotation", () => {
 
         const mockResponse = getEmptyResponse();
 
-        const token = generateTokenWithSecret1And2(
-          mockRequest,
-          mockResponse,
-          true,
-        );
+        const token = generateTokenWithSecret1And2(mockRequest, mockResponse, {
+          overwrite: true,
+        });
 
         attachResponseValuesToRequest({
           request: mockRequest,
@@ -223,11 +221,9 @@ describe("csrf-csrf token-rotation", () => {
 
         const mockResponse = getEmptyResponse();
 
-        const token = generateTokenWithSecret2And1(
-          mockRequest,
-          mockResponse,
-          true,
-        );
+        const token = generateTokenWithSecret2And1(mockRequest, mockResponse, {
+          overwrite: true,
+        });
 
         attachResponseValuesToRequest({
           request: mockRequest,

--- a/src/tests/testsuite.ts
+++ b/src/tests/testsuite.ts
@@ -119,7 +119,9 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
         // reset the mock response to have no cookies (in reality this would just be a new instance of Response)
         mockResponse.setHeader("set-cookie", []);
 
-        const generatedToken = generateToken(mockRequest, mockResponse, true);
+        const generatedToken = generateToken(mockRequest, mockResponse, {
+          overwrite: true,
+        });
         const newCookieValue = getCookieFromResponse(mockResponse);
 
         assert.notEqual(newCookieValue, oldCookieValue);
@@ -139,7 +141,10 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
               (decodedCookieValue as string).split("|")[0] + "|invalid-hash");
 
         expect(() =>
-          generateToken(mockRequest, mockResponse, false, true),
+          generateToken(mockRequest, mockResponse, {
+            overwrite: false,
+            validateOnReuse: true,
+          }),
         ).to.throw(invalidCsrfTokenError.message);
 
         // just an invalid value in the cookie
@@ -151,7 +156,10 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
           : (mockRequest.cookies[cookieName] = "invalid-value");
 
         expect(() =>
-          generateToken(mockRequest, mockResponse, false, true),
+          generateToken(mockRequest, mockResponse, {
+            overwrite: false,
+            validateOnReuse: true,
+          }),
         ).to.throw(invalidCsrfTokenError.message);
       });
 
@@ -178,12 +186,10 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
               (decodedCookieValue as string).split("|")[0] + "|invalid-hash");
         assert.doesNotThrow(
           () =>
-            (generatedToken = generateToken(
-              mockRequest,
-              mockResponse,
-              false,
-              false,
-            )),
+            (generatedToken = generateToken(mockRequest, mockResponse, {
+              overwrite: false,
+              validateOnReuse: false,
+            })),
         );
         newCookieValue = getCookieFromResponse(mockResponse);
         assert.notEqual(newCookieValue, oldCookieValue);
@@ -199,12 +205,10 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
 
         assert.doesNotThrow(
           () =>
-            (generatedToken = generateToken(
-              mockRequest,
-              mockResponse,
-              false,
-              false,
-            )),
+            (generatedToken = generateToken(mockRequest, mockResponse, {
+              overwrite: false,
+              validateOnReuse: false,
+            })),
         );
 
         newCookieValue = getCookieFromResponse(mockResponse);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,9 @@ declare module "http" {
 
 declare module "express-serve-static-core" {
   export interface Request {
-    csrfToken?: (overwrite?: boolean) => ReturnType<CsrfTokenCreator>;
+    csrfToken?: (
+      options?: GenerateCsrfTokenOptions,
+    ) => ReturnType<CsrfTokenCreator>;
   }
 }
 
@@ -51,8 +53,7 @@ export type CsrfCookieSetter = (
 export type CsrfTokenCreator = (
   req: Request,
   res: Response,
-  ovewrite?: boolean,
-  validateOnReuse?: boolean,
+  options?: GenerateCsrfTokenOptions,
 ) => string;
 export type CsrfErrorConfig = {
   statusCode: number;
@@ -60,7 +61,11 @@ export type CsrfErrorConfig = {
   code: string | undefined;
 };
 export type CsrfErrorConfigOptions = Partial<CsrfErrorConfig>;
-
+export type GenerateCsrfTokenConfig = {
+  overwrite: boolean;
+  validateOnReuse: boolean;
+};
+export type GenerateCsrfTokenOptions = Partial<GenerateCsrfTokenConfig>;
 export interface DoubleCsrfConfig {
   /**
    * A function that returns a secret or an array of secrets.


### PR DESCRIPTION
This simplifies the parameters for `generateToken`, preparing it for additional changes where the cookie configuration can be passed in on a per token basis.

This is a breaking change and won't be merged until other non-breaking changes go on first for a minor release.

It's also dependent on (and thus includes changes from): PR https://github.com/Psifi-Solutions/csrf-csrf/pull/58