### PR TITLE
Feat/per token cookie settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ string;
   <b>Default:</b> <code>"__Host-psifi.x-csrf-token"</code><br />
 </p>
 
-<p><b>Optional:</b> The name of the httpOnly cookie that will be used to track CSRF protection. If you change this it is recommend that you continue to use the <code>__Host-</code> or <code>__Secure-</code> <a target="_blank" href="developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie">security prefix</a>.</p>
+<p><b>Optional:</b> The name of the cookie that will be used to track CSRF protection. If you change this it is recommend that you continue to use the <code>__Host-</code> or <code>__Secure-</code> <a target="_blank" href="developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie">security prefix</a>.</p>
 
 <p><b>Change for development</b></p>
 
@@ -353,6 +353,7 @@ Used to customise the error response <code>statusCode</code>, the contained erro
   request: Request,
   response: Response,
   {
+    cookieOptions?: CookieOptions, // overrides cookieOptions previously configured just for this call
     overwrite?: boolean, // Set to true to force a new token to be generated
     validateOnReuse?: boolean, // Set to false to generate a new token if token re-use is invalid
   } // optional

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { HttpError } from "http-errors";
 
 export type SameSiteType = boolean | "lax" | "strict" | "none";
 export type TokenRetriever = (req: Request) => string | null | undefined;
-export type DoubleCsrfCookieOptions = Omit<CookieOptions, "httpOnly">;
+export type CsrfTokenCookieOverrides = Omit<CookieOptions, "signed">;
 declare module "http" {
   interface IncomingHttpHeaders {
     "x-csrf-token"?: string | undefined;
@@ -48,7 +48,7 @@ export type CsrfCookieSetter = (
   res: Response,
   name: string,
   value: string,
-  options: DoubleCsrfCookieOptions,
+  options: CookieOptions,
 ) => void;
 export type CsrfTokenCreator = (
   req: Request,
@@ -64,6 +64,7 @@ export type CsrfErrorConfigOptions = Partial<CsrfErrorConfig>;
 export type GenerateCsrfTokenConfig = {
   overwrite: boolean;
   validateOnReuse: boolean;
+  cookieOptions: CsrfTokenCookieOverrides;
 };
 export type GenerateCsrfTokenOptions = Partial<GenerateCsrfTokenConfig>;
 export interface DoubleCsrfConfig {
@@ -103,7 +104,7 @@ export interface DoubleCsrfConfig {
    * The options for HTTPOnly cookie that will be set on the response.
    * @default { sameSite: "lax", path: "/", secure: true }
    */
-  cookieOptions: DoubleCsrfCookieOptions;
+  cookieOptions: CookieOptions;
 
   /**
    * The methods that will be ignored by the middleware.


### PR DESCRIPTION
Provides the ability to override the `cookieOptions` on a per token generation basis.