### PR TITLE
Build/support versioned branches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,9 +5,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "v[0-9].x.x" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "v[0-9].x.x" ]
 
 permissions:
   checks: write

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,5 +176,3 @@ export interface DoubleCsrfUtilities {
    */
   doubleCsrfProtection: doubleCsrfProtection;
 }
-
-export {};


### PR DESCRIPTION
Need to keep in mind that the `branches` property doesn't use regex values. It uses `fnmatch` from ruby. It's a bit of a pain in the ass, but for now this will do until we hit v10.

This change should ensure PR's targeting `v3.x.x` and eventually `v4.x.x` get built and tested checks against them.