### PR TITLE
feat: support optional stateless association of token with session

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ When creating your doubleCsrf, you have a few options available for configuratio
 ```js
 const doubleCsrfUtilities = doubleCsrf({
   getSecret: () => "Secret", // A function that optionally takes the request and returns a secret
+  getSessionIdentifier: (req) => "", // A function that should return the session identifier for a given request
   cookieName: "__Host-psifi.x-csrf-token", // The name of the cookie to be used, recommend using Host prefix.
   cookieOptions: {
     sameSite = "lax",  // Recommend you make this strict if posible
@@ -212,6 +213,25 @@ const doubleCsrfUtilities = doubleCsrf({
 <p>This should return a secret key or an array of secret keys to be used for hashing the CSRF tokens.</p>
 <p>In case multiple are provided, the first one will be used for hashing. For validation, all secrets will be tried, preferring the first one in the array. Having multiple valid secrets can be useful when you need to rotate secrets, but you don't want to invalidate the previous secret (which might still be used by some users) right away.</p>
 </p>
+
+<h3>getSessionIdentifier</h3>
+
+```ts
+(req: Request) => string;
+```
+
+<p>
+  <b>Optional</b><br />
+  <b>Default:</b> <code>() => ""</code><br />
+</p>
+
+<p>A function that takes in the request and returns the unique session identifier for that request. For example:</p>
+
+```ts
+(req: Request) => req.session.id;
+```
+
+<p>This will ensure that CSRF tokens are signed with the unique identifier included, this means tokens will only be valid for the session that they were requested by and generated for.</p>
 
 <h3>cookieName</h3>
 

--- a/src/tests/getSessionIdentifier.test.ts
+++ b/src/tests/getSessionIdentifier.test.ts
@@ -1,0 +1,111 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { assert, expect } from "chai";
+import { doubleCsrf } from "../index.js";
+import {
+  generateMocksWithToken,
+  next,
+  RequestWithSessionId,
+} from "./utils/mock.js";
+import {
+  getSingleSecret,
+  attachResponseValuesToRequest,
+} from "./utils/helpers.js";
+
+describe("csrf-csrf with getSessionIdentifier", () => {
+  const cookieName = "xsrf-protection";
+  const sessionIdentifier = "asdf68236tr3g34fgds9fgsd9g23grb3";
+
+  const {
+    invalidCsrfTokenError,
+    generateToken,
+    validateRequest,
+    doubleCsrfProtection,
+  } = doubleCsrf({
+    cookieName,
+    getSecret: getSingleSecret,
+    getSessionIdentifier: (req) =>
+      (req as RequestWithSessionId).session.id ?? "",
+  });
+
+  it("should have a valid CSRF token for the session it was generated for", () => {
+    const { mockRequest, mockResponse } = generateMocksWithToken({
+      cookieName,
+      generateToken,
+      validateRequest,
+      signed: false,
+      sessionIdentifier,
+    });
+
+    expect(() => {
+      doubleCsrfProtection(mockRequest, mockResponse, next);
+    }, "CSRF protection should be valid").not.to.throw(invalidCsrfTokenError);
+  });
+
+  it("should not be a valid CSRF token for a session it was not generated for", () => {
+    const { mockRequest, mockResponse } = generateMocksWithToken({
+      cookieName,
+      generateToken,
+      validateRequest,
+      signed: false,
+      sessionIdentifier,
+    });
+
+    (mockRequest as RequestWithSessionId).session.id = "sdf9342dfa245r13tgvrf";
+
+    expect(() => {
+      doubleCsrfProtection(mockRequest, mockResponse, next);
+    }, "CSRF protection should be invalid").to.throw(invalidCsrfTokenError);
+  });
+
+  it("should throw when validateOnReuse is true and session has been rotated", () => {
+    const { mockRequest, mockResponse } = generateMocksWithToken({
+      cookieName,
+      generateToken,
+      validateRequest,
+      signed: false,
+      sessionIdentifier,
+    });
+
+    (mockRequest as RequestWithSessionId).session.id = "sdf9342dfa245r13tgvrf";
+
+    assert.isFalse(validateRequest(mockRequest));
+    expect(() =>
+      generateToken(mockRequest, mockResponse, {
+        overwrite: false,
+        validateOnReuse: true,
+      }),
+    ).to.throw(invalidCsrfTokenError);
+  });
+
+  it("should generate a new valid token after session has been rotated", () => {
+    const { csrfToken, mockRequest, mockResponse } = generateMocksWithToken({
+      cookieName,
+      generateToken,
+      validateRequest,
+      signed: false,
+      sessionIdentifier,
+    });
+
+    (mockRequest as RequestWithSessionId).session.id = "sdf9342dfa245r13tgvrf";
+    console.log("generating a new token");
+    const newCsrfToken = generateToken(mockRequest, mockResponse, {
+      overwrite: true,
+    });
+    console.log("new token generated");
+    assert.notEqual(
+      newCsrfToken,
+      csrfToken,
+      "New token and original token should not match",
+    );
+    attachResponseValuesToRequest({
+      request: mockRequest,
+      response: mockResponse,
+      bodyResponseToken: newCsrfToken,
+      cookieName,
+    });
+    assert.isTrue(validateRequest(mockRequest));
+    expect(() =>
+      doubleCsrfProtection(mockRequest, mockResponse, next),
+    ).not.to.throw();
+  });
+});

--- a/src/tests/utils/helpers.ts
+++ b/src/tests/utils/helpers.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+import { HEADER_KEY } from "./constants";
 
 const SECRET_1 = "secrets must be unique and must not";
 const SECRET_2 = "be used elsewhere, nor be sentences";
@@ -75,14 +76,14 @@ export const attachResponseValuesToRequest = ({
   request,
   response,
   bodyResponseToken,
-  cookieName,
-  headerKey,
+  cookieName = "__Host-psifi.x-csrf-token",
+  headerKey = HEADER_KEY,
 }: {
   request: Request;
   response: Response;
   bodyResponseToken: string;
-  cookieName: string;
-  headerKey: string;
+  cookieName?: string;
+  headerKey?: string;
 }) => {
   const { cookieValue } = getCookieValueFromResponse(response);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,10 +39,14 @@ export type RequestMethod =
   | "TRACE";
 export type CsrfIgnoredMethods = Array<RequestMethod>;
 export type CsrfRequestValidator = (req: Request) => boolean;
+export type CsrfTokenAndHashPairValidatorOptions = {
+  csrfToken: string;
+  csrfTokenHash: string;
+  possibleSecrets: Array<string>;
+  sessionIdentifier: string;
+};
 export type CsrfTokenAndHashPairValidator = (
-  token: string,
-  hash: string,
-  possibleSecrets: Array<string>,
+  options: CsrfTokenAndHashPairValidatorOptions,
 ) => boolean;
 export type CsrfCookieSetter = (
   res: Response,
@@ -87,6 +91,22 @@ export interface DoubleCsrfConfig {
    * ```
    */
   getSecret: CsrfSecretRetriever;
+
+  /**
+   * A callback which takes in the request and returns the unique session identifier for that request.
+   * The session identifier will be used when hashing the csrf token, this means a CSRF token can only
+   * be used by the session for which it was generated.
+   * Can also return a JWT if you're using that as your session identifier.
+   *
+   * @param req The request object
+   * @returns The unique session identifier for the incoming request
+   * @default () => ''
+   * @example
+   * ```js
+   * const getSessionIdentifier = (req) => req.session.id;
+   * ```
+   */
+  getSessionIdentifier: (req: Request) => string;
 
   /**
    * The name of the HTTPOnly cookie that will be set on the response.


### PR DESCRIPTION
Natively support session <> CSRF token association so CSRF tokens are only valid for the session they are generated for.