### PR TITLE
Fix some very minor README defects

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
     Do read the <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html">OWASP - Cross-Site Request Forgery Prevention Cheat Sheet</a>
   </li>
   <li>
-    Do read the <a href="  https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html">OWASP - Secrets Management Cheat Sheet</a>
+    Do read the <a href="https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html">OWASP - Secrets Management Cheat Sheet</a>
   </li>
   <li>
     Do follow the <a href="#configuration">recommendations when configuring</a> csrf-csrf.
@@ -244,10 +244,10 @@ string;
   <b>Default:</b> <code>"__Host-psifi.x-csrf-token"</code><br />
 </p>
 
-<p><b>Optional:</b> The name of the cookie that will be used to track CSRF protection. If you change this it is recommend that you continue to use the <code>__Host-</code> or <code>__Secure-</code> <a target="_blank" href="developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie">security prefix</a>.</p>
+<p><b>Optional:</b> The name of the cookie that will be used to track CSRF protection. If you change this it is recommend that you continue to use the <code>__Host-</code> or <code>__Secure-</code> <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie">security prefix</a>.</p>
 
 <p><b>Change for development</b></p>
-f
+
 <p>The security prefix requires the secure flag to be true and requires requests to be received via HTTPS, unless you have your local instance running via HTTPS, you will need to change this value in your development environment.</p>
 
 <h3>cookieOptions</h3>
@@ -444,7 +444,7 @@ req.csrfToken(req, res, { overwrite: false, validateOnReuse: false });
     Join the <a href="https://discord.gg/JddkbuSnUU">Discord</a> and ask for help in the <code>psifi-support</code> channel.
   </li>
   <li>
-    Pledge your support through the <a href="">Patreon</a>
+    Pledge your support through the <a href="https://patreon.com/Psibean">Patreon</a>
   </li>
 </ul>
 


### PR DESCRIPTION
While taking a look at the README for the project, I noticed an errant character and a broken link on the npm page due to no scheme in the URL. I looked at the file and noticed a couple of other things too.Just thought I'd try to make the world a (very slightly) better place with some small fixes. Here is the list:

1. Removed some spaces between the `href="` and the URL.
2. Added `https://` in front of a URL so that it would link properly from NPM's copy.
3. Removed a seemingly accidental `f`.
4. Added the link to the Patreon for this project because it was missing.

I realize this doesn't really add _much_ value to the project, but I hope it helps just a little. Thanks for a great library!