### PR TITLE
build: fix the broken tsup setup

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,25 +36,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v4
     
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 20.x
         cache: 'npm'
     
     - name: Install Node Dependencies
       run: npm ci
   
     - name: Build
-      run: npm run build:code --if-present
+      run: npm run build --if-present
   
     - name: Run tests
       run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ node_modules/
 
 # vscode
 .vscode/
-lib/
+dist/
 
 # example
 example/**/package-lock.json

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
   "files": {
-    "ignore": ["node_modules", "lib", "package-lock.json"]
+    "ignore": ["node_modules", "dist", "package-lock.json"]
   },
   "formatter": {
     "enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,6 @@
     "rules": {
       "recommended": true,
       "style": {
-        "useNodejsImportProtocol": "off",
         "useImportType": "off"
       }
     }

--- a/example/complete/src/index.js
+++ b/example/complete/src/index.js
@@ -2,8 +2,8 @@ import cookieParser from "cookie-parser";
 import { doubleCsrf } from "csrf-csrf";
 import express from "express";
 
-import path from "path";
-import { fileURLToPath } from "url";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 

--- a/package.json
+++ b/package.json
@@ -3,36 +3,31 @@
   "version": "3.0.7",
   "description": "A utility package to help implement stateless CSRF protection using the Double Submit Cookie Pattern in express.",
   "type": "module",
-  "main": "./lib/cjs/index.cjs",
+  "main": "./dist/index.cjs",
   "exports": {
     ".": {
       "require": {
-        "types": "./lib/index.d.cts",
-        "default": "./lib/cjs/index.cjs"
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
       },
       "import": {
-        "types": "./lib/index.d.ts",
-        "default": "./lib/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
-  "types": "./lib/index.d.ts",
-  "files": ["lib/esm/index.js", "lib/cjs/index.cjs", "lib/index.d.ts", "lib/index.d.cts"],
+  "types": "./dist/index.d.ts",
+  "files": ["dist/index.js", "dist/index.cjs", "dist/index.d.ts", "dist/index.d.cts"],
   "scripts": {
-    "test": "mocha --recursive ./src/tests/*.test.ts",
-    "clean": "rm -rf ./lib",
-    "lint": "biome check .",
-    "lint:fix": "biome check",
-    "prettify": "biome check --write .",
-    "build:types": "npx tsup src/index.ts --out-dir lib --dts-only --format esm,cjs",
-    "build:cjs": "tsc -p tsconfig.cjs.json && mv ./lib/cjs/index.js ./lib/cjs/index.cjs && rm ./lib/cjs/types.js",
-    "build:esm": "tsc -p tsconfig.json && rm ./lib/esm/types.js",
-    "build:code": "npm run build:cjs && npm run build:esm",
-    "build": "npm run build:types && npm run build:code",
+    "build": "tsup",
     "build:clean": "npm run clean && npm run build",
+    "changelog": "commit-and-tag-version",
+    "clean": "rm -rf ./dist",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
     "pack": "npm pack",
     "pack:clean": "rm -rf *.tgz && npm run pack",
-    "changelog": "commit-and-tag-version"
+    "test": "mocha --recursive ./src/tests/*.test.ts"
   },
   "author": "psibean",
   "license": "ISC",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes } from "crypto";
+import { createHmac, randomBytes } from "node:crypto";
 import type { Request, Response } from "express";
 import createHttpError from "http-errors";
 

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "CommonJS",
-    "outDir": "./lib/cjs"
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,17 +6,19 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": false,
-    "rootDir": "./src",
-    "outDir": "./lib/esm",
     "baseUrl": ".",
     "strictNullChecks": true,
     "isolatedModules": false,
     "declaration": false,
     "removeComments": true,
     "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
     "paths": {
-      "*": ["node_modules/*"]
-    }
+      "@/*": ["./src/*"]
+    },
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "files": ["./src/index.ts"]
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["./src/**/*", "./example/**/*"]
-}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: {
+      index: "src/index.ts",
+    },
+    format: ["cjs", "esm"],
+    target: "node14",
+    splitting: false,
+    sourcemap: false,
+    clean: true,
+    minify: false,
+    dts: true,
+    outDir: "dist",
+  },
+]);


### PR DESCRIPTION
* Flattens the build output.
* Changed output from lib to dist.
* Rely on tsup to output with Node 14 compatibility. Only build and test with Node 20.
* Perhaps tests should be added that test running the built package with Node 14/16/18/20.
* The package doesn't need to be build time compatible with < Node 20, only run time.