### PR TITLE
feat: add optional skipCsrfProtection callback config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ const doubleCsrfUtilities = doubleCsrf({
   size: 64, // The size of the generated tokens in bits
   ignoredMethods: ["GET", "HEAD", "OPTIONS"], // A list of request methods that will not be protected.
   getTokenFromRequest: (req) => req.headers["x-csrf-token"], // A function that returns the token from the request
+  skipCsrfProtection: undefined // An optional function that is called to determine whether the current request should be protected
 });
 ```
 
@@ -366,6 +367,18 @@ code?: string | undefined;
 ```
 
 Used to customise the error response <code>statusCode</code>, the contained error <code>message</code>, and it's <code>code</code>, the error is constructed via <code>createHttpError</code>. The default values match that of <code>csurf</code> for convenience.
+
+<h3 id="skip-csrf-protection">skipCsrfProtection</h3>
+
+```ts
+(req: Request) => boolean;
+```
+
+<p><b>Optional - Use this option with extreme caution*</b></p>
+
+<p>Used to determine whether CSRF protection should be skipped for the given request. If this callback is provided and the request is not in the <code>ignoredMethods</code>, then the callback will be called to determine whether or not CSRF token validation should be checked. If it returns <code>true</code> the CSRF protection will be skipped, if it returns <code>false</code> then CSRF protection will be checked.<p>
+
+<p>* It is primarily provided to avoid the need of wrapping the middleware in your own middleware, allowing you to apply a global logic as to whether or not CSRF protection should be executed based on the incoming request. You should <b>only</b> skip CSRF protection for cases you are 100% certain it is safe to do so, for example, requests you have identified as coming from a native app. You should ensure you are not introducing any vulnerabilities that would allow your web based app to circumvent the protection via CSRF attacks. This option is <b>NOT</b> a solution for CSRF errors.</p>
 
 <h2 id="utilities">Utilities</h2>
 

--- a/src/tests/doublecsrf.test.ts
+++ b/src/tests/doublecsrf.test.ts
@@ -30,6 +30,7 @@ createTestSuite("csrf-csrf signed with custom options, single secret", {
   size: 128,
   cookieName: "__Host.test-the-thing.token",
   delimiter: ":",
+  skipCsrfProtection: () => false,
 });
 
 createTestSuite("csrf-csrf unsigned, multiple secrets", {

--- a/src/tests/skipCsrfProtection.test.ts
+++ b/src/tests/skipCsrfProtection.test.ts
@@ -1,0 +1,71 @@
+import { assert, expect } from "chai";
+import { doubleCsrf } from "../index.js";
+import { getSingleSecret } from "./utils/helpers.js";
+import { generateMocks, next } from "./utils/mock.js";
+
+describe("csrf-csrf with skipCsrfProtection", () => {
+  it("should skip CSRF protection when skipCsrfProtection returns true", () => {
+    const { doubleCsrfProtection } = doubleCsrf({
+      getSecret: getSingleSecret,
+      skipCsrfProtection: () => true,
+    });
+
+    const { mockResponse, mockRequest } = generateMocks();
+    mockRequest.method = "POST";
+    assert.isUndefined(mockRequest.csrfToken);
+    expect(() =>
+      doubleCsrfProtection(mockRequest, mockResponse, next),
+    ).to.not.throw();
+    assert.isFunction(mockRequest.csrfToken);
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const testSkipCsrfProtectionFalsey = (skipCsrfProtection?: any) => {
+    const { doubleCsrfProtection } = doubleCsrf({
+      getSecret: getSingleSecret,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      skipCsrfProtection,
+    });
+
+    const { mockResponse, mockRequest } = generateMocks();
+    mockRequest.method = "POST";
+
+    assert.isUndefined(mockRequest.csrfToken);
+    expect(() =>
+      doubleCsrfProtection(mockRequest, mockResponse, next),
+    ).to.throw();
+    assert.isFunction(mockRequest.csrfToken);
+  };
+
+  it("should not skip CSRF protection when skipCsrfProtection returns false", () => {
+    testSkipCsrfProtectionFalsey(() => false);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns null", () => {
+    testSkipCsrfProtectionFalsey(() => null);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns undefined", () => {
+    testSkipCsrfProtectionFalsey(() => undefined);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns empty string", () => {
+    testSkipCsrfProtectionFalsey(() => "");
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns empty object", () => {
+    testSkipCsrfProtectionFalsey(() => ({}));
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns 1", () => {
+    testSkipCsrfProtectionFalsey(() => 1);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection is null", () => {
+    testSkipCsrfProtectionFalsey(null);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection is undefined", () => {
+    testSkipCsrfProtectionFalsey(undefined);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,19 @@ export interface DoubleCsrfConfig {
    * @default { statusCode: 403, message: "invalid csrf token", code: "EBADCSRFTOKEN" }
    */
   errorConfig: CsrfErrorConfigOptions;
+
+  /**
+   * Use this with extreme caution, for example, use it to avoid CSRF protection
+   * for a native app but still have it for the web app. It's crucial you know
+   * when skipping CSRF protection is safe for your use case.
+   * @param req The request object
+   * @returns true if the request does not need csrf protection, false if it does
+   * @example
+   * ```js
+   * const skipCsrfProtection = (req) => isNativeApp(req);
+   * ```
+   */
+  skipCsrfProtection: (req: Request) => boolean;
 }
 
 export interface DoubleCsrfUtilities {


### PR DESCRIPTION
This brings a new optional and backwards compatible feature.

A discussion on the Discord led me to realise that if you wanted or needed a global way or a dynamic way to determine whether CSRF protection should be skipped for any given request, the only way to do this was by wrapping the `doubleCsrfProtection` middleware in your own middleware.

This PR brings in the `skipCsrfProtection` callback option to solve this use case. This allows users to explicitly avoid CSRF protection for cases where a native app is calling the same API's as a web based app, or in rare cases where specific requests do not require protection.

The documentation has been updated with extreme caution towards using this option and advises not to introduce vulnerabilities. `csrf-csrf` itself is explicitly checking the type of `skipCsrfProtection` to be a function before calling it and is also explicitly checking the return type is a boolean. This is to ensure that `csrf-csrf` itself doesn't create accidental loose ends.

Given the risk of introducing this option, I would like this to be reviewed with scrutiny before merging.

Testing has been introduced via `skipCsrfProtection.test.ts` with explicit type and linting being ignored to ensure the JavaScript edge cases are explicitly tested. Additionally one of the existing test suites has been updated to include `skipCsrfProtection: () => false`.