### PR TITLE
fix(types): fix incorrect type for Request#csrfToken

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,10 @@ declare module "http" {
 
 declare module "express-serve-static-core" {
   export interface Request {
-    csrfToken?: (overwrite?: boolean) => ReturnType<CsrfTokenCreator>;
+    csrfToken?: (
+      overwrite?: boolean,
+      validateOnReuse?: boolean,
+    ) => ReturnType<CsrfTokenCreator>;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/Psifi-Solutions/csrf-csrf/issues/95, incorrect typing on `Request#csrfToken` making the `validateOnReuse` parameter inaccessible, which is potentially critical given it currently defaults to true.