### PR TITLE
feat!: change default value of sameSite to 'strict'

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ const doubleCsrfUtilities = doubleCsrf({
   getSessionIdentifier: (req) => req.session.id, // A function that returns the session identifier for the request
   cookieName: "__Host-psifi.x-csrf-token", // The name of the cookie to be used, recommend using Host prefix.
   cookieOptions: {
-    sameSite = "lax",  // Recommend you make this strict if posible
+    sameSite = "strict",
     path = "/",
     secure = true,
     httpOnly = false,
@@ -266,7 +266,7 @@ string;
 
 ```ts
 {
-  sameSite: "lax",
+  sameSite: "strict",
   path: "/",
   secure: true
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export function doubleCsrf({
   getSecret,
   getSessionIdentifier,
   cookieName = "__Host-psifi.x-csrf-token",
-  cookieOptions: { sameSite = "lax", path = "/", secure = true, httpOnly = false, ...remainingCookieOptions } = {},
+  cookieOptions: { sameSite = "strict", path = "/", secure = true, httpOnly = false, ...remainingCookieOptions } = {},
   messageDelimiter = "!",
   csrfTokenDelimiter = ".",
   size = 32,

--- a/src/tests/doublecsrf.test.ts
+++ b/src/tests/doublecsrf.test.ts
@@ -23,6 +23,9 @@ createTestSuite("csrf-csrf default configuration with single secret", {
 createTestSuite("csrf-csrf default configuration with multiple secrets", {
   getSecret: getMultipleSecrets,
   getSessionIdentifier: (req) => req.session.id ?? "",
+  cookieOptions: {
+    sameSite: "lax",
+  },
 });
 
 createTestSuite("csrf-csrf with custom options, multiple secrets", {

--- a/src/tests/testsuite.ts
+++ b/src/tests/testsuite.ts
@@ -28,7 +28,7 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
     const {
       cookieName = "__Host-psifi.x-csrf-token",
       csrfTokenDelimiter = ".",
-      cookieOptions: { path = "/", secure = true, sameSite = "lax", httpOnly = false } = {},
+      cookieOptions: { path = "/", secure = true, sameSite = "strict", httpOnly = false } = {},
       errorConfig = {
         statusCode: 403,
         message: "invalid csrf token",

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export interface DoubleCsrfConfig {
 
   /**
    * The options for HTTPOnly cookie that will be set on the response.
-   * @default { sameSite: "lax", path: "/", secure: true }
+   * @default { sameSite: "strict", path: "/", secure: true }
    */
   cookieOptions: CsrfTokenCookieOptions;
 


### PR DESCRIPTION
BREAKING CHANGE: If you were previously dependent on the sameSite value being 'lax' and you weren't explicitly setting it then you will need to set it now.

The reason for this change is to try and make csrf-csrf more secure by default. The idea being that when you need to make a change to the configuration, you should be actively thinking about that change and determining whether it is correct. This is to help encourage people to consult the documentation regarding configuration considerations.