### PR TITLE
feat: set httpOnly default back to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ const doubleCsrfUtilities = doubleCsrf({
     sameSite = "strict",
     path = "/",
     secure = true,
-    httpOnly = false,
+    httpOnly = true,
     ...remainingCookieOptions // See cookieOptions below
   },
   size: 32, // The size of the random value used to construct the message used for hmac generation

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export function doubleCsrf({
   getSecret,
   getSessionIdentifier,
   cookieName = "__Host-psifi.x-csrf-token",
-  cookieOptions: { sameSite = "strict", path = "/", secure = true, httpOnly = false, ...remainingCookieOptions } = {},
+  cookieOptions: { sameSite = "strict", path = "/", secure = true, httpOnly = true, ...remainingCookieOptions } = {},
   messageDelimiter = "!",
   csrfTokenDelimiter = ".",
   size = 32,

--- a/src/tests/testsuite.ts
+++ b/src/tests/testsuite.ts
@@ -28,7 +28,7 @@ export const createTestSuite: CreateTestsuite = (name, doubleCsrfOptions) => {
     const {
       cookieName = "__Host-psifi.x-csrf-token",
       csrfTokenDelimiter = ".",
-      cookieOptions: { path = "/", secure = true, sameSite = "strict", httpOnly = false } = {},
+      cookieOptions: { path = "/", secure = true, sameSite = "strict", httpOnly = true } = {},
       errorConfig = {
         statusCode: 403,
         message: "invalid csrf token",

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export interface DoubleCsrfConfig {
 
   /**
    * The options for HTTPOnly cookie that will be set on the response.
-   * @default { sameSite: "strict", path: "/", secure: true }
+   * @default { sameSite: "strict", path: "/", secure: true, httpOnly: true }
    */
   cookieOptions: CsrfTokenCookieOptions;
 


### PR DESCRIPTION
This is non-breaking as it reverts a previously unreleased breaking change to false. The change means less breaking changes with v4, less risk, and the WIP v4 documentation is intended to try and better guide users around appropriate configuration.

The idea is that users should be properly determining whether a particular config change is appropriate, they should make sure they understand what the configuration does and what impact changing it may have.